### PR TITLE
fix(deps): add overrides to reduce security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2406,6 +2406,126 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@jsonjoy.com/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/buffers": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+			"integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/codegen": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+			"integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pack": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+			"integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/base64": "^1.1.2",
+				"@jsonjoy.com/buffers": "^1.2.0",
+				"@jsonjoy.com/codegen": "^1.0.0",
+				"@jsonjoy.com/json-pointer": "^1.0.2",
+				"@jsonjoy.com/util": "^1.9.0",
+				"hyperdyperid": "^1.2.0",
+				"thingies": "^2.5.0",
+				"tree-dump": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pointer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+			"integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/codegen": "^1.0.0",
+				"@jsonjoy.com/util": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/util": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+			"integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/buffers": "^1.0.0",
+				"@jsonjoy.com/codegen": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
 		"node_modules/@keyv/serialize": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
@@ -3077,19 +3197,6 @@
 			}
 		},
 		"node_modules/@types/express-serve-static-core": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.0.tgz",
-			"integrity": "sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"@types/qs": "*",
-				"@types/range-parser": "*",
-				"@types/send": "*"
-			}
-		},
-		"node_modules/@types/express/node_modules/@types/express-serve-static-core": {
 			"version": "4.19.7",
 			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.7.tgz",
 			"integrity": "sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==",
@@ -3223,9 +3330,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+			"integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3831,33 +3938,6 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/@vue/cli-shared-utils/node_modules/cross-spawn": {
-			"version": "6.0.6",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
-			"integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			},
-			"engines": {
-				"node": ">=4.8"
-			}
-		},
-		"node_modules/@vue/cli-shared-utils/node_modules/cross-spawn/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
 		"node_modules/@vue/cli-shared-utils/node_modules/execa": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -3949,29 +4029,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/@vue/cli-shared-utils/node_modules/shebang-command": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@vue/cli-shared-utils/node_modules/shebang-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@vue/cli-shared-utils/node_modules/signal-exit": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -3990,19 +4047,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/@vue/cli-shared-utils/node_modules/which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"which": "bin/which"
 			}
 		},
 		"node_modules/@vue/cli-shared-utils/node_modules/yallist": {
@@ -4102,31 +4146,6 @@
 			"dependencies": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
-			}
-		},
-		"node_modules/@vue/component-compiler-utils/node_modules/picocolors": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/@vue/component-compiler-utils/node_modules/postcss": {
-			"version": "7.0.39",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-			"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"picocolors": "^0.2.1",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
 			}
 		},
 		"node_modules/@vue/component-compiler-utils/node_modules/prettier": {
@@ -5035,6 +5054,22 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/bundle-name": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"run-applescript": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -5383,23 +5418,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/clipboardy/node_modules/cross-spawn": {
-			"version": "6.0.6",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
-			"integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			},
-			"engines": {
-				"node": ">=4.8"
-			}
-		},
 		"node_modules/clipboardy/node_modules/execa": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -5465,58 +5483,12 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/clipboardy/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
-		"node_modules/clipboardy/node_modules/shebang-command": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/clipboardy/node_modules/shebang-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/clipboardy/node_modules/signal-exit": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/clipboardy/node_modules/which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"which": "bin/which"
-			}
 		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
@@ -6401,6 +6373,36 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/default-browser": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.4.0.tgz",
+			"integrity": "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bundle-name": "^4.1.0",
+				"default-browser-id": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser-id": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+			"integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/default-gateway": {
@@ -8031,13 +8033,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/fs-monkey": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
-			"integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
-			"dev": true,
-			"license": "Unlicense"
-		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -8196,6 +8191,23 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/glob-to-regex.js": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+			"integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
 			}
 		},
 		"node_modules/glob-to-regexp": {
@@ -8512,23 +8524,6 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
-		"node_modules/html-entities": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
-			"integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/mdevils"
-				},
-				{
-					"type": "patreon",
-					"url": "https://patreon.com/mdevils"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -8728,6 +8723,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/typicode"
+			}
+		},
+		"node_modules/hyperdyperid": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+			"integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.18"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -8989,6 +8994,41 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^3.0.0"
+			},
+			"bin": {
+				"is-inside-container": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-inside-container/node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-interactive": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -8997,6 +9037,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-network-error": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.0.tgz",
+			"integrity": "sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-number": {
@@ -9939,16 +9992,22 @@
 			}
 		},
 		"node_modules/memfs": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
-			"integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.51.0.tgz",
+			"integrity": "sha512-4zngfkVM/GpIhC8YazOsM6E8hoB33NP0BCESPOA6z7qaL6umPJNqkO8CNYaLV2FB2MV6H1O3x2luHHOSqppv+A==",
 			"dev": true,
-			"license": "Unlicense",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"fs-monkey": "^1.0.4"
+				"@jsonjoy.com/json-pack": "^1.11.0",
+				"@jsonjoy.com/util": "^1.9.0",
+				"glob-to-regex.js": "^1.0.1",
+				"thingies": "^2.5.0",
+				"tree-dump": "^1.0.3",
+				"tslib": "^2.0.0"
 			},
-			"engines": {
-				"node": ">= 4.0.0"
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
 			}
 		},
 		"node_modules/meow": {
@@ -10251,13 +10310,6 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/nice-try": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10708,17 +10760,21 @@
 			}
 		},
 		"node_modules/p-retry": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+			"integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/retry": "0.12.0",
+				"@types/retry": "0.12.2",
+				"is-network-error": "^1.0.0",
 				"retry": "^0.13.1"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-try": {
@@ -12455,6 +12511,19 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/run-applescript": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+			"integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -14085,6 +14154,23 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/thingies": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/thingies/-/thingies-2.5.0.tgz",
+			"integrity": "sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "^2"
+			}
+		},
 		"node_modules/thread-loader": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-3.0.4.tgz",
@@ -14240,6 +14326,23 @@
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/tree-dump": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+			"integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
 		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
@@ -14878,27 +14981,60 @@
 			}
 		},
 		"node_modules/webpack-dev-middleware": {
-			"version": "5.3.4",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
-			"integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
+			"integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"colorette": "^2.0.10",
-				"memfs": "^3.4.3",
-				"mime-types": "^2.1.31",
+				"memfs": "^4.43.1",
+				"mime-types": "^3.0.1",
+				"on-finished": "^2.4.1",
 				"range-parser": "^1.2.1",
 				"schema-utils": "^4.0.0"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
+				"webpack": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"webpack": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/webpack-dev-middleware/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/webpack-dev-middleware/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/webpack-dev-middleware/node_modules/schema-utils": {
@@ -14922,55 +15058,53 @@
 			}
 		},
 		"node_modules/webpack-dev-server": {
-			"version": "4.15.2",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
-			"integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
+			"integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/bonjour": "^3.5.9",
-				"@types/connect-history-api-fallback": "^1.3.5",
-				"@types/express": "^4.17.13",
-				"@types/serve-index": "^1.9.1",
-				"@types/serve-static": "^1.13.10",
-				"@types/sockjs": "^0.3.33",
-				"@types/ws": "^8.5.5",
+				"@types/bonjour": "^3.5.13",
+				"@types/connect-history-api-fallback": "^1.5.4",
+				"@types/express": "^4.17.21",
+				"@types/express-serve-static-core": "^4.17.21",
+				"@types/serve-index": "^1.9.4",
+				"@types/serve-static": "^1.15.5",
+				"@types/sockjs": "^0.3.36",
+				"@types/ws": "^8.5.10",
 				"ansi-html-community": "^0.0.8",
-				"bonjour-service": "^1.0.11",
-				"chokidar": "^3.5.3",
+				"bonjour-service": "^1.2.1",
+				"chokidar": "^3.6.0",
 				"colorette": "^2.0.10",
 				"compression": "^1.7.4",
 				"connect-history-api-fallback": "^2.0.0",
-				"default-gateway": "^6.0.3",
-				"express": "^4.17.3",
+				"express": "^4.21.2",
 				"graceful-fs": "^4.2.6",
-				"html-entities": "^2.3.2",
-				"http-proxy-middleware": "^2.0.3",
-				"ipaddr.js": "^2.0.1",
-				"launch-editor": "^2.6.0",
-				"open": "^8.0.9",
-				"p-retry": "^4.5.0",
-				"rimraf": "^3.0.2",
-				"schema-utils": "^4.0.0",
-				"selfsigned": "^2.1.1",
+				"http-proxy-middleware": "^2.0.9",
+				"ipaddr.js": "^2.1.0",
+				"launch-editor": "^2.6.1",
+				"open": "^10.0.3",
+				"p-retry": "^6.2.0",
+				"schema-utils": "^4.2.0",
+				"selfsigned": "^2.4.1",
 				"serve-index": "^1.9.1",
 				"sockjs": "^0.3.24",
 				"spdy": "^4.0.2",
-				"webpack-dev-middleware": "^5.3.4",
-				"ws": "^8.13.0"
+				"webpack-dev-middleware": "^7.4.2",
+				"ws": "^8.18.0"
 			},
 			"bin": {
 				"webpack-dev-server": "bin/webpack-dev-server.js"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.37.0 || ^5.0.0"
+				"webpack": "^5.0.0"
 			},
 			"peerDependenciesMeta": {
 				"webpack": {
@@ -15006,6 +15140,19 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/webpack-dev-server/node_modules/define-lazy-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/webpack-dev-server/node_modules/glob-parent": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -15017,6 +15164,25 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/open": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+			"integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"default-browser": "^5.2.1",
+				"define-lazy-prop": "^3.0.0",
+				"is-inside-container": "^1.0.0",
+				"wsl-utils": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/webpack-dev-server/node_modules/readdirp": {
@@ -15275,6 +15441,38 @@
 				}
 			}
 		},
+		"node_modules/wsl-utils": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+			"integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-wsl": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/wsl-utils/node_modules/is-wsl": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-inside-container": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/xml-name-validator": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
@@ -15398,18 +15596,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/yorkie/node_modules/cross-spawn": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-			"integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"lru-cache": "^4.0.1",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			}
-		},
 		"node_modules/yorkie/node_modules/execa": {
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
@@ -15449,17 +15635,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/yorkie/node_modules/lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
-			}
-		},
 		"node_modules/yorkie/node_modules/normalize-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
@@ -15493,53 +15668,10 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/yorkie/node_modules/shebang-command": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/yorkie/node_modules/shebang-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/yorkie/node_modules/signal-exit": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/yorkie/node_modules/which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"which": "bin/which"
-			}
-		},
-		"node_modules/yorkie/node_modules/yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
 			"dev": true,
 			"license": "ISC"
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vue-gh-pages",
-	"version": "3.1.5",
+	"version": "3.1.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vue-gh-pages",
-			"version": "3.1.5",
+			"version": "3.1.6",
 			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.1.5",
+	"version": "3.1.6",
 	"private": true,
 	"name": "vue-gh-pages",
 	"description": "Tutorial to publish a public repository made with Vue in GithubPages.",

--- a/package.json
+++ b/package.json
@@ -62,5 +62,18 @@
 	"engines": {
 		"node": "20.18.0",
 		"npm": "10.8.2"
+	},
+	"overrides": {
+		"cross-spawn": "^7.0.6",
+		"webpack-dev-server": "^5.2.1",
+		"yorkie": "^2.0.0",
+		"@vue/component-compiler-utils": {
+			"postcss": "^8.4.47"
+		},
+		"vue-loader": {
+			"@vue/component-compiler-utils": {
+				"postcss": "^8.4.47"
+			}
+		}
 	}
 }


### PR DESCRIPTION
# fix(deps): add overrides to reduce security vulnerabilities

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P0 | S | 20-11-2025 | 20-11-2025 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| <img width="833" alt="Screenshot 2025-11-20 a las 21 22 12" src="https://github.com/user-attachments/assets/34ac3da9-75e8-4f3a-95da-1d4216fc4913" /> | <img width="730" alt="Screenshot 2025-11-20 a las 21 26 43" src="https://github.com/user-attachments/assets/19e57c94-226b-45c7-bc0f-4929b560ce7c" /> |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [ ] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary

> [!CAUTION]
> ```bash
> $ npm audit
> 14 vulnerabilities (1 low, 9 moderate, 4 high)
> ```

- Add npm `overrides` section to `package.json` to force secure versions of transitive dependencies
- Reduce security vulnerabilities from 14 to 7 (50% reduction), eliminating all HIGH severity issues

## 📋 Changes Made

### Dependencies
- Update `postcss` from ^8.4.31 to ^8.4.47 in devDependencies
- Add `overrides` section to `package.json` with:
  - `cross-spawn`: ^7.0.6 (fixes HIGH severity ReDoS vulnerability)
  - `webpack-dev-server`: ^5.2.1 (fixes MODERATE severity source code theft)
  - `yorkie`: ^2.0.0 (includes cross-spawn security fix)
  - `postcss`: ^8.4.47 in `@vue/component-compiler-utils` (fixes MODERATE severity parsing error)
  - `postcss`: ^8.4.47 in `vue-loader` (fixes MODERATE severity parsing error)
- Update `package-lock.json` with new dependency resolutions

## 🧪 Tests

- [x] Verify vulnerability reduction:

```bash
npm audit
```
- [x] Confirm application builds without errors:

```bash
npm run build
```
- [x] Verify lint passes without errors:

```bash
npm run lint
```
- [x] Verify dev server starts correctly:

```bash
npm run serve
```
- [x] Verify no regression in existing functionality

## 📌 Notes

### Vulnerable packages
| Package | Version | Severity | Dependency chain | Advisory |
| --- | --- | --- | --- | --- |
| `cross-spawn` | `<7.0.5` | 🔴 | `yorkie` → `cross-spawn` | [GHSA-3xgq-45jj-v275](https://github.com/advisories/GHSA-3xgq-45jj-v275) |
| `webpack-dev-server` | `<5.2.0` | 🔴 | `@vue/cli-service` → `webpack-dev-server` | [GHSA-9jgg-88mc-972h](https://github.com/advisories/GHSA-9jgg-88mc-972h) |
| `postcss` | `<8.4.31` | 🔴 | `@vue/cli-service` → `postcss`<br>`css-loader` → `postcss` | [GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)<br>[GHSA-5j4c-8p2g-v4jx](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx) |
| `vue` | `2.7.16` | 🟡 | Direct dependency | [GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx) |
| `vue-template-compiler` | `2.7.16` | 🟡 | Direct dependency | — |

### Security overrides
| Package | Version | Severity | Advisory |
| --- | --- | --- | --- |
| `cross-spawn` | `7.0.6` | 🔴 | [GHSA-3xgq-45jj-v275](https://github.com/advisories/GHSA-3xgq-45jj-v275) |
| `webpack-dev-server` | `5.2.1` | 🔴 | [GHSA-9jgg-88mc-972h](https://github.com/advisories/GHSA-9jgg-88mc-972h) |
| `postcss` | `8.4.47` | 🟡 | [GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j) |

### Vulnerability reduction summary after fix
| Severity | Before | After | Reduction |
| --- | --- | --- | --- |
| 🔴 HIGH | 4 | 0 | 100% |
| 🟡 MODERATE | 9 | 6 | 33% |
| 🟢 LOW | 1 | 1 | 0% |
| **TOTAL** | **14** | **7** | **50%** |

> [!WARNING]
> ```bash
> $ npm audit
> 7 vulnerabilities (1 low, 6 moderate)
> ```

**Reduction:** 14 → 7 vulnerabilities (50% reduction)

### Remaining vulnerabilities after fix
| Package | Version | Why it can't be fixed | Advisory |
| --- | --- | --- | --- |
| `vue` | `2.7.16` | Requires `vue@3` upgrade<br>(major breaking change) | [GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx) |
| `vue-template-compiler` | `2.7.16` | Requires `vue@3` upgrade<br>(major breaking change) | — |

These remaining vulnerabilities are in the core `vue@2` framework and affect only development/build tooling, not production runtime.

## 🔗 References

### Documentation
- [GHSA-3xgq-45jj-v275](https://github.com/advisories/GHSA-3xgq-45jj-v275)
- [GHSA-9jgg-88mc-972h](https://github.com/advisories/GHSA-9jgg-88mc-972h)
- [GHSA-4v9v-hfq4-rm2v](https://github.com/advisories/GHSA-4v9v-hfq4-rm2v)
- [GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
- [GHSA-5j4c-8p2g-v4jx](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx)
- [GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
- https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides

### Related Issues
- Closes #842