### PR TITLE
hotfix(3.3.2): update commitlint config to match standard across repositories

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -6,11 +6,37 @@ export default {
 		"body-max-line-length": [
 			2,
 			"always",
-			800,
+			10000,
 		],
 		"footer-leading-blank": [
 			0,
 			"always",
+		],
+		"footer-max-line-length": [
+			2,
+			"always",
+			10000,
+		],
+		"header-max-length": [
+			2,
+			"always",
+			150,
+		],
+		"type-enum": [
+			2,
+			"always",
+			[
+				"build",
+				"ci",
+				"docs",
+				"feat",
+				"fix",
+				"perf",
+				"refactor",
+				"revert",
+				"style",
+				"test",
+			],
 		],
 	},
 };

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -8,5 +8,9 @@ export default {
 			"always",
 			800,
 		],
+		"footer-leading-blank": [
+			0,
+			"always",
+		],
 	},
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vue-gh-pages",
-	"version": "3.3.1",
+	"version": "3.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vue-gh-pages",
-			"version": "3.3.1",
+			"version": "3.3.2",
 			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.3.1",
+	"version": "3.3.2",
 	"private": true,
 	"name": "vue-gh-pages",
 	"description": "Tutorial to publish a public repository made with Vue in GithubPages.",


### PR DESCRIPTION
# hotfix(3.3.2): update commitlint config to match standard across repositories

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P3 | XS | 22-12-2025 | 22-12-2025 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [x] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary

- Update commitlint configuration to match the standard used across all repositories

## 📋 Changes Made

### Configuration
- Update `body-max-line-length` rule from 800 to 10000 characters
- Add `footer-leading-blank` rule disabled (value 0) to avoid warnings
- Add `footer-max-line-length` rule with 10000 characters limit
- Add `header-max-length` rule with 150 characters limit
- Add `type-enum` rule with standard conventional commit types: `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`

### Version
- Bump version from `3.3.1` to `3.3.2` in `package.json` and `package-lock.json`

## 🧪 Tests

- [x] Run build without errors:

```bash
npm run build
```
- [x] Verify the code follows the project's style guidelines
- [x] Verify commits don't show `footer-leading-blank` warning

## 📌 Notes

The commitlint configuration was inconsistent with other repositories, causing warnings like `footer must have leading blank line [footer-leading-blank]` during commits.

## 🔗 References

### Related Issues
- Closes #880