### PR TITLE
hotfix(3.4.1): add support for major version limit in `update-node-npm.yml`

### DIFF
--- a/.github/workflows/update-node-npm.yml
+++ b/.github/workflows/update-node-npm.yml
@@ -14,6 +14,12 @@
 # - package.json (engines.node and engines.npm)
 # - .github/workflows/check-node.yml (matrix node-version)
 
+# Optional configuration file (.noderc.json):
+# {
+#   "maxMajorVersion": 22  // Limits updates to this major version (receives minor/patch only)
+# }
+# If the file doesn't exist, the workflow will update to the latest LTS version.
+
 name: 📦 Create PR to update Node and NPM versions
 
 on:
@@ -38,6 +44,26 @@ jobs:
         with:
           token: ${{ secrets.PAT_WORKFLOW }}
 
+      - name: 📋 Read configuration
+        id: config
+        run: |
+          # Check if .noderc.json exists
+          if [ -f .noderc.json ]; then
+            echo "📄 Configuration file found"
+            MAX_MAJOR=$(jq -r '.maxMajorVersion // empty' .noderc.json)
+            if [ -n "$MAX_MAJOR" ]; then
+              echo "🔒 Max major version configured: $MAX_MAJOR"
+              echo "has_config=true" >> $GITHUB_OUTPUT
+              echo "max_major=$MAX_MAJOR" >> $GITHUB_OUTPUT
+            else
+              echo "⚠️ Configuration file exists but maxMajorVersion not set"
+              echo "has_config=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "📄 No configuration file found, using latest LTS"
+            echo "has_config=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: 🌐 Get Node.js LTS versions info
         id: node-versions
         run: |
@@ -50,37 +76,71 @@ jobs:
           # Get current date
           CURRENT_DATE=$(date +%Y-%m-%d)
 
-          # Find active LTS versions (started and not ended)
-          ACTIVE_LTS=$(echo "$RELEASES" | jq -r --arg date "$CURRENT_DATE" '
-            to_entries |
-            map(select(
-              .value.start <= $date and
-              .value.end >= $date and
-              .value.lts != null and
-              .value.lts <= $date
-            )) |
-            map(.key | ltrimstr("v") | tonumber) |
-            sort |
-            .[-2:]
-          ')
+          # Check if maxMajorVersion is configured
+          HAS_CONFIG="${{ steps.config.outputs.has_config }}"
+          MAX_MAJOR="${{ steps.config.outputs.max_major }}"
+
+          if [ "$HAS_CONFIG" == "true" ]; then
+            echo "🔒 Using configured max major version: $MAX_MAJOR"
+            TARGET_MAJOR=$MAX_MAJOR
+
+            # For matrix, find the previous LTS version
+            ACTIVE_LTS=$(echo "$RELEASES" | jq -r --arg date "$CURRENT_DATE" --argjson max "$MAX_MAJOR" '
+              to_entries |
+              map(select(
+                .value.start <= $date and
+                .value.end >= $date and
+                .value.lts != null and
+                .value.lts <= $date and
+                (.key | ltrimstr("v") | tonumber) <= $max
+              )) |
+              map(.key | ltrimstr("v") | tonumber) |
+              sort |
+              .[-2:]
+            ')
+
+            LTS_OLDEST=$(echo "$ACTIVE_LTS" | jq '.[0]')
+            LTS_LATEST=$(echo "$ACTIVE_LTS" | jq '.[1] // .[0]')
+
+            # If only one version in array, use it for both
+            if [ "$LTS_LATEST" == "null" ] || [ -z "$LTS_LATEST" ]; then
+              LTS_LATEST=$LTS_OLDEST
+            fi
+          else
+            echo "📦 Using latest LTS version (no config)"
+
+            # Find active LTS versions (started and not ended)
+            ACTIVE_LTS=$(echo "$RELEASES" | jq -r --arg date "$CURRENT_DATE" '
+              to_entries |
+              map(select(
+                .value.start <= $date and
+                .value.end >= $date and
+                .value.lts != null and
+                .value.lts <= $date
+              )) |
+              map(.key | ltrimstr("v") | tonumber) |
+              sort |
+              .[-2:]
+            ')
+
+            LTS_OLDEST=$(echo "$ACTIVE_LTS" | jq '.[0]')
+            LTS_LATEST=$(echo "$ACTIVE_LTS" | jq '.[1]')
+            TARGET_MAJOR=$LTS_LATEST
+          fi
 
           echo "Active LTS versions: $ACTIVE_LTS"
-
-          # Get the two active LTS major versions for the matrix
-          LTS_OLDEST=$(echo "$ACTIVE_LTS" | jq '.[0]')
-          LTS_LATEST=$(echo "$ACTIVE_LTS" | jq '.[1]')
-
           echo "LTS oldest: $LTS_OLDEST"
           echo "LTS latest: $LTS_LATEST"
+          echo "Target major: $TARGET_MAJOR"
 
-          # Get the latest version of the newest LTS
-          LATEST_VERSION=$(echo "$ALL_VERSIONS" | jq -r --argjson major "$LTS_LATEST" '
+          # Get the latest version of the target major
+          LATEST_VERSION=$(echo "$ALL_VERSIONS" | jq -r --argjson major "$TARGET_MAJOR" '
             map(select(.version | startswith("v\($major)."))) |
             .[0].version |
             ltrimstr("v")
           ')
 
-          echo "Latest LTS version: $LATEST_VERSION"
+          echo "Latest version for major $TARGET_MAJOR: $LATEST_VERSION"
 
           # Get npm version bundled with this Node version
           NPM_VERSION=$(echo "$ALL_VERSIONS" | jq -r --arg ver "v$LATEST_VERSION" '
@@ -96,6 +156,7 @@ jobs:
           echo "lts_oldest=$LTS_OLDEST" >> $GITHUB_OUTPUT
           echo "lts_latest=$LTS_LATEST" >> $GITHUB_OUTPUT
           echo "matrix=[ $LTS_OLDEST, $LTS_LATEST ]" >> $GITHUB_OUTPUT
+          echo "has_version_limit=$HAS_CONFIG" >> $GITHUB_OUTPUT
 
       - name: 📖 Get current versions
         id: current-versions
@@ -254,6 +315,15 @@ jobs:
             UPDATE_BADGE="![Up to date](https://img.shields.io/badge/Status-Up%20to%20Date-green)"
           fi
 
+          # Set version limit badge
+          if [ "${{ steps.config.outputs.has_config }}" == "true" ]; then
+            VERSION_LIMIT_BADGE="![Limited](https://img.shields.io/badge/Version%20Limit-v${{ steps.config.outputs.max_major }}-blue)"
+            CONFIG_ICON="✅ maxMajorVersion: ${{ steps.config.outputs.max_major }}"
+          else
+            VERSION_LIMIT_BADGE="![No Limit](https://img.shields.io/badge/Version%20Limit-None-gray)"
+            CONFIG_ICON="❌ Not configured"
+          fi
+
           if [ "${{ steps.current-versions.outputs.has_nvmrc }}" == "true" ]; then
             NVMRC_ICON="✅ Found"
           else
@@ -275,14 +345,14 @@ jobs:
           cat >> $GITHUB_STEP_SUMMARY << EOF
           # Node.js Update Check Summary
 
-          ${UPDATE_BADGE}
+          ${UPDATE_BADGE} ${VERSION_LIMIT_BADGE}
 
           > 📅 Last check: $(date +%d-%m-%Y)
 
           ## 🔢 Version Comparison
 
-          | Package | Current | → | Latest LTS |
-          |---------|:-------:|:-:|:----------:|
+          | Package | Current | → | Latest |
+          |---------|:-------:|:-:|:------:|
           | **Node.js** | \`${{ steps.current-versions.outputs.current_node }}\` | → | \`${{ steps.node-versions.outputs.latest_version }}\` |
           | **npm** | \`${{ steps.current-versions.outputs.current_npm }}\` | → | \`${{ steps.node-versions.outputs.npm_version }}\` |
           | **CI Matrix** | \`${{ steps.current-versions.outputs.current_matrix }}\` | → | \`${{ steps.node-versions.outputs.matrix }}\` |
@@ -291,6 +361,7 @@ jobs:
 
           | File | Status | Description |
           |------|:------:|-------------|
+          | \`.noderc.json\` | ${CONFIG_ICON} | Version limit configuration |
           | \`.nvmrc\` | ${NVMRC_ICON} | Node version for nvm |
           | \`package.json\` | ${ENGINES_ICON} | Engines of node and npm |
           | \`check-node.yml\` | ${NODE_YML_ICON} | CI workflow matrix |

--- a/.noderc.json
+++ b/.noderc.json
@@ -1,0 +1,3 @@
+{
+	"maxMajorVersion": 22
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 ![GitHub dependabot](https://img.shields.io/badge/dependabot-enabled-025e8c?logo=Dependabot)
+![node](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/beatrizsmerino/vue-gh-pages/master/package.json&query=$.engines.node&label=node&logo=node.js&color=339933)
+![npm](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/beatrizsmerino/vue-gh-pages/master/package.json&query=$.engines.npm&label=npm&logo=npm&color=CB3837)  
 ![GitHub last commit](https://img.shields.io/github/last-commit/beatrizsmerino/vue-gh-pages)
 ![GitHub issues](https://img.shields.io/github/issues/beatrizsmerino/vue-gh-pages)
 ![GitHub forks](https://img.shields.io/github/forks/beatrizsmerino/vue-gh-pages)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vue-gh-pages",
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vue-gh-pages",
-			"version": "3.4.0",
+			"version": "3.4.1",
 			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"private": true,
 	"name": "vue-gh-pages",
 	"description": "Tutorial to publish a public repository made with Vue in GithubPages.",


### PR DESCRIPTION
# hotfix(3.4.1): add support for major version limit in `update-node-npm.yml`

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P2 | S | 26-12-2025 | 26-12-2025 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [x] Configuration
- [x] Documentation
- [x] CI/CD

## 📝 Summary

- Add optional `.noderc.json` configuration file to limit the maximum major version in `update-node-npm.yml`
- Fix workflow always updating to latest Node.js LTS causing problems with incompatible majors (e.g., Node 24)

## 📋 Changes Made

### Configuration
- Add `.noderc.json` configuration file with `maxMajorVersion: 22`

### CI/CD
- Add step to read configuration file if exists
- Modify version selection logic to respect `maxMajorVersion`
- Update summary to show version limit badge and config status

### Documentation
- Add dynamic badges for `node` and `npm` versions in README

### Version
- Bump version from `3.4.0` to `3.4.1`

## 🧪 Tests

- [x] Verify workflow respects `maxMajorVersion` when `.noderc.json` exists
- [x] Verify minor/patch updates work correctly within the limited major

## 📌 Notes

- The `.noderc.json` file is optional
- Repos without restrictions keep the current behavior
- Repos with restrictions continue receiving security patches (minor/patch)
- The file can be removed when the incompatibility is resolved

## 🔗 References

### Related Issues
- Closes #884