### PR TITLE
release(3.6.0): license, configuration and dependency improvements

### DIFF
--- a/.github/workflows/check-node.yml
+++ b/.github/workflows/check-node.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
     steps:
       - name: 🔀 Checkout code from repository
         uses: actions/checkout@v6.0.1

--- a/.github/workflows/check-node.yml
+++ b/.github/workflows/check-node.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [22.22.1]
     steps:
       - name: 🔀 Checkout code from repository
         uses: actions/checkout@v6.0.1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: 🛠️ Setup Node version
         uses: actions/setup-node@v6.3.0
         with:
-          node-version: 22.x
+          node-version: 22.22.1
       - name: 📦 Install dependencies
         run: npm install
       - name: 🙍‍♂️ Setup git user

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: 🛠️ Setup Node version
         uses: actions/setup-node@v6.3.0
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: 📦 Install dependencies
         run: npm install
       - name: 🙍‍♂️ Setup git user

--- a/.github/workflows/update-node-npm.yml
+++ b/.github/workflows/update-node-npm.yml
@@ -156,7 +156,7 @@ jobs:
           echo "npm_version=$NPM_VERSION" >> $GITHUB_OUTPUT
           echo "lts_oldest=$LTS_OLDEST" >> $GITHUB_OUTPUT
           echo "lts_latest=$LTS_LATEST" >> $GITHUB_OUTPUT
-          echo "matrix=[$LTS_LATEST]" >> $GITHUB_OUTPUT
+          echo "matrix=[$LATEST_VERSION]" >> $GITHUB_OUTPUT
           echo "has_version_limit=$HAS_CONFIG" >> $GITHUB_OUTPUT
 
       - name: 📖 Get current versions
@@ -243,7 +243,7 @@ jobs:
       - name: 📝 Update deploy.yml node-version
         if: steps.check-update.outputs.update_needed == 'true'
         run: |
-          sed -i "s/node-version: [0-9]*\.x/node-version: ${{ steps.node-versions.outputs.lts_latest }}.x/" .github/workflows/deploy.yml
+          sed -i "s/node-version: [0-9][0-9.]*/node-version: ${{ steps.node-versions.outputs.latest_version }}/" .github/workflows/deploy.yml
           echo "Updated deploy.yml node-version"
           grep "node-version:" .github/workflows/deploy.yml
 
@@ -266,7 +266,7 @@ jobs:
             - Update `package.json` file in `engines.node`: ${{ steps.current-versions.outputs.current_node }} → ${{ steps.node-versions.outputs.latest_version }}
             - Update `package.json` file in `engines.npm`: ${{ steps.current-versions.outputs.current_npm }} → ${{ steps.node-versions.outputs.npm_version }}
             - Update `check-node.yml` file in matrix: ${{ steps.current-versions.outputs.current_matrix }} → ${{ steps.node-versions.outputs.matrix }}
-            - Update `deploy.yml` file in node-version: ${{ steps.node-versions.outputs.lts_latest }}.x
+            - Update `deploy.yml` file in node-version: ${{ steps.node-versions.outputs.latest_version }}
           title: "build(deps): update `node@${{ steps.node-versions.outputs.latest_version }}` and `npm@${{ steps.node-versions.outputs.npm_version }}` versions"
           body: |
             # build(deps): update `node@${{ steps.node-versions.outputs.latest_version }}` and `npm@${{ steps.node-versions.outputs.npm_version }}` versions
@@ -295,7 +295,7 @@ jobs:
             - Update `package.json` file in `engines.node`: `${{ steps.current-versions.outputs.current_node }}` → `${{ steps.node-versions.outputs.latest_version }}`
             - Update `package.json` file in `engines.npm`: `${{ steps.current-versions.outputs.current_npm }}` → `${{ steps.node-versions.outputs.npm_version }}`
             - Update `check-node.yml` file in matrix: `${{ steps.current-versions.outputs.current_matrix }}` → `${{ steps.node-versions.outputs.matrix }}`
-            - Update `deploy.yml` file in node-version: `${{ steps.node-versions.outputs.lts_latest }}.x`
+            - Update `deploy.yml` file in node-version: `${{ steps.node-versions.outputs.latest_version }}`
 
             ## 🧪 Tests
 

--- a/.github/workflows/update-node-npm.yml
+++ b/.github/workflows/update-node-npm.yml
@@ -13,6 +13,7 @@
 # - .nvmrc
 # - package.json (engines.node and engines.npm)
 # - .github/workflows/check-node.yml (matrix node-version)
+# - .github/workflows/deploy.yml (node-version)
 
 # Optional configuration file (.noderc.json):
 # {
@@ -239,6 +240,13 @@ jobs:
           echo "Updated check-node.yml matrix"
           grep "node-version:" .github/workflows/check-node.yml
 
+      - name: 📝 Update deploy.yml node-version
+        if: steps.check-update.outputs.update_needed == 'true'
+        run: |
+          sed -i "s/node-version: [0-9]*\.x/node-version: ${{ steps.node-versions.outputs.lts_latest }}.x/" .github/workflows/deploy.yml
+          echo "Updated deploy.yml node-version"
+          grep "node-version:" .github/workflows/deploy.yml
+
       - name: 🚀 Create Pull Request
         if: |
           steps.check-update.outputs.update_needed == 'true' &&
@@ -258,6 +266,7 @@ jobs:
             - Update `package.json` file in `engines.node`: ${{ steps.current-versions.outputs.current_node }} → ${{ steps.node-versions.outputs.latest_version }}
             - Update `package.json` file in `engines.npm`: ${{ steps.current-versions.outputs.current_npm }} → ${{ steps.node-versions.outputs.npm_version }}
             - Update `check-node.yml` file in matrix: ${{ steps.current-versions.outputs.current_matrix }} → ${{ steps.node-versions.outputs.matrix }}
+            - Update `deploy.yml` file in node-version: ${{ steps.node-versions.outputs.lts_latest }}.x
           title: "build(deps): update `node@${{ steps.node-versions.outputs.latest_version }}` and `npm@${{ steps.node-versions.outputs.npm_version }}` versions"
           body: |
             # build(deps): update `node@${{ steps.node-versions.outputs.latest_version }}` and `npm@${{ steps.node-versions.outputs.npm_version }}` versions
@@ -286,6 +295,7 @@ jobs:
             - Update `package.json` file in `engines.node`: `${{ steps.current-versions.outputs.current_node }}` → `${{ steps.node-versions.outputs.latest_version }}`
             - Update `package.json` file in `engines.npm`: `${{ steps.current-versions.outputs.current_npm }}` → `${{ steps.node-versions.outputs.npm_version }}`
             - Update `check-node.yml` file in matrix: `${{ steps.current-versions.outputs.current_matrix }}` → `${{ steps.node-versions.outputs.matrix }}`
+            - Update `deploy.yml` file in node-version: `${{ steps.node-versions.outputs.lts_latest }}.x`
 
             ## 🧪 Tests
 
@@ -340,6 +350,12 @@ jobs:
             NODE_YML_ICON="❌ Not found"
           fi
 
+          if [ -f .github/workflows/deploy.yml ]; then
+            DEPLOY_YML_ICON="✅ Found"
+          else
+            DEPLOY_YML_ICON="❌ Not found"
+          fi
+
           cat >> $GITHUB_STEP_SUMMARY << EOF
           # Node.js Update Check Summary
 
@@ -363,6 +379,7 @@ jobs:
           | \`.nvmrc\` | ${NVMRC_ICON} | Node version for nvm |
           | \`package.json\` | ${ENGINES_ICON} | Engines of node and npm |
           | \`check-node.yml\` | ${NODE_YML_ICON} | CI workflow matrix |
+          | \`deploy.yml\` | ${DEPLOY_YML_ICON} | Deploy workflow node-version |
 
           ## 🔗 Resources
 

--- a/.github/workflows/update-node-npm.yml
+++ b/.github/workflows/update-node-npm.yml
@@ -156,7 +156,7 @@ jobs:
           echo "npm_version=$NPM_VERSION" >> $GITHUB_OUTPUT
           echo "lts_oldest=$LTS_OLDEST" >> $GITHUB_OUTPUT
           echo "lts_latest=$LTS_LATEST" >> $GITHUB_OUTPUT
-          echo "matrix=[ $LTS_OLDEST, $LTS_LATEST ]" >> $GITHUB_OUTPUT
+          echo "matrix=[$LTS_LATEST]" >> $GITHUB_OUTPUT
           echo "has_version_limit=$HAS_CONFIG" >> $GITHUB_OUTPUT
 
       - name: 📖 Get current versions

--- a/.noderc.json
+++ b/.noderc.json
@@ -1,3 +1,0 @@
-{
-	"maxMajorVersion": 22
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vue-gh-pages",
-	"version": "3.5.1",
+	"version": "3.6.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vue-gh-pages",
-			"version": "3.5.1",
+			"version": "3.6.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"chalk": "^5.6.0",
+				"chalk": "^5.6.2",
 				"core-js": "^3.48.0",
 				"execa": "^9.6.1",
 				"node-emoji": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13094,16 +13094,6 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
 		"node_modules/range-parser": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -13825,13 +13815,13 @@
 			"license": "MIT"
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
+			"integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"dependencies": {
-				"randombytes": "^2.1.0"
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/serve-index": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1787,17 +1787,17 @@
 			}
 		},
 		"node_modules/@commitlint/cli": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.4.3.tgz",
-			"integrity": "sha512-Z37EMoDT7+Upg500vlr/vZrgRsb6Xc5JAA3Tv7BYbobnN/ZpqUeZnSLggBg2+1O+NptRDtyujr2DD1CPV2qwhA==",
+			"version": "20.4.4",
+			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.4.4.tgz",
+			"integrity": "sha512-GLMNQHYGcn0ohL2HMlAnXcD1PS2vqBBGbYKlhrRPOYsWiRoLWtrewsR3uKRb9v/IdS+qOS0vqJQ64n1g8VPKFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/format": "^20.4.3",
-				"@commitlint/lint": "^20.4.3",
-				"@commitlint/load": "^20.4.3",
-				"@commitlint/read": "^20.4.3",
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/format": "^20.4.4",
+				"@commitlint/lint": "^20.4.4",
+				"@commitlint/load": "^20.4.4",
+				"@commitlint/read": "^20.4.4",
+				"@commitlint/types": "^20.4.4",
 				"tinyexec": "^1.0.0",
 				"yargs": "^17.0.0"
 			},
@@ -1809,13 +1809,13 @@
 			}
 		},
 		"node_modules/@commitlint/config-conventional": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.4.3.tgz",
-			"integrity": "sha512-9RtLySbYQAs8yEqWEqhSZo9nYhbm57jx7qHXtgRmv/nmeQIjjMcwf6Dl+y5UZcGWgWx435TAYBURONaJIuCjWg==",
+			"version": "20.4.4",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.4.4.tgz",
+			"integrity": "sha512-Usg+XXbPNG2GtFWTgRURNWCge1iH1y6jQIvvklOdAbyn2t8ajfVwZCnf5t5X4gUsy17BOiY+myszGsSMIvhOVA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/types": "^20.4.4",
 				"conventional-changelog-conventionalcommits": "^9.2.0"
 			},
 			"engines": {
@@ -1823,13 +1823,13 @@
 			}
 		},
 		"node_modules/@commitlint/config-validator": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.4.3.tgz",
-			"integrity": "sha512-jCZpZFkcSL3ZEdL5zgUzFRdytv3xPo8iukTe9VA+QGus/BGhpp1xXSVu2B006GLLb2gYUAEGEqv64kTlpZNgmA==",
+			"version": "20.4.4",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.4.4.tgz",
+			"integrity": "sha512-K8hMS9PTLl7EYe5vWtSFQ/sgsV2PHUOtEnosg8k3ZQxCyfKD34I4C7FxWEfRTR54rFKeUYmM3pmRQqBNQeLdlw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/types": "^20.4.4",
 				"ajv": "^8.11.0"
 			},
 			"engines": {
@@ -1837,13 +1837,13 @@
 			}
 		},
 		"node_modules/@commitlint/ensure": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.4.3.tgz",
-			"integrity": "sha512-WcXGKBNn0wBKpX8VlXgxqedyrLxedIlLBCMvdamLnJFEbUGJ9JZmBVx4vhLV3ZyA8uONGOb+CzW0Y9HDbQ+ONQ==",
+			"version": "20.4.4",
+			"resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.4.4.tgz",
+			"integrity": "sha512-QivV0M1MGL867XCaF+jJkbVXEPKBALhUUXdjae66hes95aY1p3vBJdrcl3x8jDv2pdKWvIYIz+7DFRV/v0dRkA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/types": "^20.4.4",
 				"lodash.camelcase": "^4.3.0",
 				"lodash.kebabcase": "^4.1.1",
 				"lodash.snakecase": "^4.1.1",
@@ -1865,13 +1865,13 @@
 			}
 		},
 		"node_modules/@commitlint/format": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.4.3.tgz",
-			"integrity": "sha512-UDJVErjLbNghop6j111rsHJYGw6MjCKAi95K0GT2yf4eeiDHy3JDRLWYWEjIaFgO+r+dQSkuqgJ1CdMTtrvHsA==",
+			"version": "20.4.4",
+			"resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.4.4.tgz",
+			"integrity": "sha512-jLi/JBA4GEQxc5135VYCnkShcm1/rarbXMn2Tlt3Si7DHiiNKHm4TaiJCLnGbZ1r8UfwDRk+qrzZ80kwh08Aow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/types": "^20.4.4",
 				"picocolors": "^1.1.1"
 			},
 			"engines": {
@@ -1879,13 +1879,13 @@
 			}
 		},
 		"node_modules/@commitlint/is-ignored": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.4.3.tgz",
-			"integrity": "sha512-W5VQKZ7fdJ1X3Tko+h87YZaqRMGN1KvQKXyCM8xFdxzMIf1KCZgN4uLz3osLB1zsFcVS4ZswHY64LI26/9ACag==",
+			"version": "20.4.4",
+			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.4.4.tgz",
+			"integrity": "sha512-y76rT8yq02x+pMDBI2vY4y/ByAwmJTkta/pASbgo8tldBiKLduX8/2NCRTSCjb3SumE5FBeopERKx3oMIm8RTQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/types": "^20.4.4",
 				"semver": "^7.6.0"
 			},
 			"engines": {
@@ -1906,32 +1906,32 @@
 			}
 		},
 		"node_modules/@commitlint/lint": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.4.3.tgz",
-			"integrity": "sha512-CYOXL23e+nRKij81+d0+dymtIi7Owl9QzvblJYbEfInON/4MaETNSLFDI74LDu+YJ0ML5HZyw9Vhp9QpckwQ0A==",
+			"version": "20.4.4",
+			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.4.4.tgz",
+			"integrity": "sha512-svOEW+RptcNpXKE7UllcAsV0HDIdOck9reC2TP1QA6K5Fo0xxQV+QPjV8Zqx9g6X/hQBkF2S9ZQZ78Xrv1Eiog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/is-ignored": "^20.4.3",
-				"@commitlint/parse": "^20.4.3",
-				"@commitlint/rules": "^20.4.3",
-				"@commitlint/types": "^20.4.3"
+				"@commitlint/is-ignored": "^20.4.4",
+				"@commitlint/parse": "^20.4.4",
+				"@commitlint/rules": "^20.4.4",
+				"@commitlint/types": "^20.4.4"
 			},
 			"engines": {
 				"node": ">=v18"
 			}
 		},
 		"node_modules/@commitlint/load": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.4.3.tgz",
-			"integrity": "sha512-3cdJOUVP+VcgHa7bhJoWS+Z8mBNXB5aLWMBu7Q7uX8PSeWDzdbrBlR33J1MGGf7r1PZDp+mPPiFktk031PgdRw==",
+			"version": "20.4.4",
+			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.4.4.tgz",
+			"integrity": "sha512-kvFrzvoIACa/fMjXEP0LNEJB1joaH3q3oeMJsLajXE5IXjYrNGVcW1ZFojXUruVJ7odTZbC3LdE/6+ONW4f2Dg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/config-validator": "^20.4.3",
+				"@commitlint/config-validator": "^20.4.4",
 				"@commitlint/execute-rule": "^20.0.0",
-				"@commitlint/resolve-extends": "^20.4.3",
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/resolve-extends": "^20.4.4",
+				"@commitlint/types": "^20.4.4",
 				"cosmiconfig": "^9.0.1",
 				"cosmiconfig-typescript-loader": "^6.1.0",
 				"is-plain-obj": "^4.1.0",
@@ -1953,13 +1953,13 @@
 			}
 		},
 		"node_modules/@commitlint/parse": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.4.3.tgz",
-			"integrity": "sha512-hzC3JCo3zs3VkQ833KnGVuWjWIzR72BWZWjQM7tY/7dfKreKAm7fEsy71tIFCRtxf2RtMP2d3RLF1U9yhFSccA==",
+			"version": "20.4.4",
+			"resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.4.4.tgz",
+			"integrity": "sha512-AjfgOgrjEozeQNzhFu1KL5N0nDx4JZmswVJKNfOTLTUGp6xODhZHCHqb//QUHKOzx36If5DQ7tci2o7szYxu1A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/types": "^20.4.4",
 				"conventional-changelog-angular": "^8.2.0",
 				"conventional-commits-parser": "^6.3.0"
 			},
@@ -1968,15 +1968,15 @@
 			}
 		},
 		"node_modules/@commitlint/read": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.4.3.tgz",
-			"integrity": "sha512-j42OWv3L31WfnP8WquVjHZRt03w50Y/gEE8FAyih7GQTrIv2+pZ6VZ6pWLD/ml/3PO+RV2SPtRtTp/MvlTb8rQ==",
+			"version": "20.4.4",
+			"resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.4.4.tgz",
+			"integrity": "sha512-jvgdAQDdEY6L8kCxOo21IWoiAyNFzvrZb121wU2eBxI1DzWAUZgAq+a8LlJRbT0Qsj9INhIPVWgdaBbEzlF0dQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@commitlint/top-level": "^20.4.3",
-				"@commitlint/types": "^20.4.3",
-				"git-raw-commits": "^4.0.0",
+				"@commitlint/types": "^20.4.4",
+				"git-raw-commits": "^5.0.0",
 				"minimist": "^1.2.8",
 				"tinyexec": "^1.0.0"
 			},
@@ -1985,14 +1985,14 @@
 			}
 		},
 		"node_modules/@commitlint/resolve-extends": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.4.3.tgz",
-			"integrity": "sha512-QucxcOy+00FhS9s4Uy0OyS5HeUV+hbC6OLqkTSIm6fwMdKva+OEavaCDuLtgd9akZZlsUo//XzSmPP3sLKBPog==",
+			"version": "20.4.4",
+			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.4.4.tgz",
+			"integrity": "sha512-pyOf+yX3c3m/IWAn2Jop+7s0YGKPQ8YvQaxt9IQxnLIM3yZAlBdkKiQCT14TnrmZTkVGTXiLtckcnFTXYwlY0A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/config-validator": "^20.4.3",
-				"@commitlint/types": "^20.4.3",
+				"@commitlint/config-validator": "^20.4.4",
+				"@commitlint/types": "^20.4.4",
 				"global-directory": "^4.0.1",
 				"import-meta-resolve": "^4.0.0",
 				"lodash.mergewith": "^4.6.2",
@@ -2003,16 +2003,16 @@
 			}
 		},
 		"node_modules/@commitlint/rules": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.4.3.tgz",
-			"integrity": "sha512-Yuosd7Grn5qiT7FovngXLyRXTMUbj9PYiSkvUgWK1B5a7+ZvrbWDS7epeUapYNYatCy/KTpPFPbgLUdE+MUrBg==",
+			"version": "20.4.4",
+			"resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.4.4.tgz",
+			"integrity": "sha512-PmUp8QPLICn9w05dAx5r1rdOYoTk7SkfusJJh5tP3TqHwo2mlQ9jsOm8F0HSXU9kuLfgTEGNrunAx/dlK/RyPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/ensure": "^20.4.3",
+				"@commitlint/ensure": "^20.4.4",
 				"@commitlint/message": "^20.4.3",
 				"@commitlint/to-lines": "^20.0.0",
-				"@commitlint/types": "^20.4.3"
+				"@commitlint/types": "^20.4.4"
 			},
 			"engines": {
 				"node": ">=v18"
@@ -2042,9 +2042,9 @@
 			}
 		},
 		"node_modules/@commitlint/types": {
-			"version": "20.4.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.4.3.tgz",
-			"integrity": "sha512-51OWa1Gi6ODOasPmfJPq6js4pZoomima4XLZZCrkldaH2V5Nb3bVhNXPeT6XV0gubbainSpTw4zi68NqAeCNCg==",
+			"version": "20.4.4",
+			"resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.4.4.tgz",
+			"integrity": "sha512-dwTGzyAblFXHJNBOgrTuO5Ee48ioXpS5XPRLLatxhQu149DFAHUcB3f0Q5eea3RM4USSsP1+WVT2dBtLVod4fg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2053,6 +2053,46 @@
 			},
 			"engines": {
 				"node": ">=v18"
+			}
+		},
+		"node_modules/@conventional-changelog/git-client": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.6.0.tgz",
+			"integrity": "sha512-T+uPDciKf0/ioNNDpMGc8FDsehJClZP0yR3Q5MN6wE/Y/1QZ7F+80OgznnTCOlMEG4AV0LvH2UJi3C/nBnaBUg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@simple-libs/child-process-utils": "^1.0.0",
+				"@simple-libs/stream-utils": "^1.2.0",
+				"semver": "^7.5.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"conventional-commits-filter": "^5.0.0",
+				"conventional-commits-parser": "^6.3.0"
+			},
+			"peerDependenciesMeta": {
+				"conventional-commits-filter": {
+					"optional": true
+				},
+				"conventional-commits-parser": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@conventional-changelog/git-client/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
@@ -3504,6 +3544,22 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/@simple-libs/child-process-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
+			"integrity": "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@simple-libs/stream-utils": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/dangreen"
+			}
+		},
 		"node_modules/@simple-libs/stream-utils": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
@@ -3842,9 +3898,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.4.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.4.0.tgz",
-			"integrity": "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+			"integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5430,9 +5486,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-			"integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+			"version": "2.10.7",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.7.tgz",
+			"integrity": "sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -5795,9 +5851,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001777",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
-			"integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
+			"version": "1.0.30001778",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001778.tgz",
+			"integrity": "sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==",
 			"dev": true,
 			"funding": [
 				{
@@ -6989,19 +7045,6 @@
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
 			"license": "MIT"
 		},
-		"node_modules/dargs": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
-			"integrity": "sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/de-indent": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -7510,9 +7553,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.307",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
-			"integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+			"version": "1.5.313",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
+			"integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -7801,9 +7844,9 @@
 			}
 		},
 		"node_modules/eslint-json-compat-utils": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/eslint-json-compat-utils/-/eslint-json-compat-utils-0.2.2.tgz",
-			"integrity": "sha512-KcTUifi8VSSHkrOY0FzB7smuTZRU9T2nCrcCy6k2b+Q77+uylBQVIxN4baVCIWvWJEpud+IsrYgco4JJ6io05g==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/eslint-json-compat-utils/-/eslint-json-compat-utils-0.2.3.tgz",
+			"integrity": "sha512-RbBmDFyu7FqnjE8F0ZxPNzx5UaptdeS9Uu50r7A+D7s/+FCX+ybiyViYEgFUaFIFqSWJgZRTpL5d8Kanxxl2lQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8810,35 +8853,20 @@
 			}
 		},
 		"node_modules/git-raw-commits": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-4.0.0.tgz",
-			"integrity": "sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==",
-			"deprecated": "This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz",
+			"integrity": "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"dargs": "^8.0.0",
-				"meow": "^12.0.1",
-				"split2": "^4.0.0"
+				"@conventional-changelog/git-client": "^2.6.0",
+				"meow": "^13.0.0"
 			},
 			"bin": {
-				"git-raw-commits": "cli.mjs"
+				"git-raw-commits": "src/cli.js"
 			},
 			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/git-raw-commits/node_modules/meow": {
-			"version": "12.1.1",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
-			"integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16.10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=18"
 			}
 		},
 		"node_modules/glob": {
@@ -14246,16 +14274,6 @@
 				"wbuf": "^1.7.3"
 			}
 		},
-		"node_modules/split2": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">= 10.x"
-			}
-		},
 		"node_modules/ssri": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -15321,9 +15339,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+			"integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"deploy:v2": "node deploy-v2.mjs"
 	},
 	"dependencies": {
-		"chalk": "^5.6.0",
+		"chalk": "^5.6.2",
 		"core-js": "^3.48.0",
 		"execa": "^9.6.1",
 		"node-emoji": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -83,10 +83,16 @@
 		"npm": "10.9.4"
 	},
 	"overrides": {
-		"stylelint-config-recommended": "17.0.0",
 		"cross-spawn": "^7.0.6",
-		"webpack-dev-server": "^5.2.1",
-		"yorkie": "^2.0.0",
+		"stylelint-config-recommended-vue": {
+			"stylelint-config-recommended": "17.0.0"
+		},
+		"@vue/cli-service": {
+			"webpack-dev-server": "^5.2.1"
+		},
+		"@vue/cli-plugin-eslint": {
+			"yorkie": "^2.0.0"
+		},
 		"@vue/component-compiler-utils": {
 			"postcss": "^8.4.47"
 		},

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
 			"stylelint-config-recommended": "17.0.0"
 		},
 		"@vue/cli-service": {
+			"serialize-javascript": "^7.0.4",
 			"webpack-dev-server": "^5.2.1"
 		},
 		"@vue/cli-plugin-eslint": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.5.1",
+	"version": "3.6.0",
 	"private": true,
 	"name": "vue-gh-pages",
 	"description": "Tutorial to publish a public repository made with Vue in GithubPages.",


### PR DESCRIPTION
# release(3.6.0): license, configuration and dependency improvements

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 2h | P1 | M | 13-03-2026 | 13-03-2026 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change
- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [x] New feature
- [x] Improvement
- [x] Configuration
- [x] Documentation
- [x] CI/CD

## 📝 Summary

- Minor release with license, configuration and dependency improvements
- Includes `stylelint` peer dependency fix, `prettier` YAML formatting and `serialize-javascript` override
- Overrides scoped to specific consumers to improve maintainability
- Fixes `check-node.yml` matrix incompatibility with `engine-strict=true`
- Pins exact Node versions in all workflows to match `engines.node`

## 📋 Changes Made

### Bug Fixes
- Remove deprecated `baseUrl` option from `jsconfig.json`

### Configuration

#### License
- Add missing `LICENSE` file with `MIT` and update `package.json` license from `ISC` to `MIT`

#### Prettier
- Rename JSON config files to `.json` extension
- Add `.prettierrc` to `prettier:fix` script
- Add `YAML` override to `.prettierrc.json` and `YAML` to `prettier:fix` script
- Add `printWidth` to `YAML` override in `.prettierrc.json`
- Add `YAML` section to `.editorconfig`

#### EditorConfig
- Sort properties alphabetically in `[*]` section
- Update header comment with documentation URL

#### ESLint
- Remove `vue-gh-pages.code-workspace` file

### New Features
- Create `.npmrc` with `engine-strict=true`

### Improvements
- Convert `author` from string to JSON object in `package.json`
- Format `.prettierrc` with correct array style

### Dependencies
- Resolve `stylelint` peer dependency warnings
- Update `chalk` to latest patch version
- Scope global overrides to specific consumers
- Add `serialize-javascript` override to reduce vulnerabilities

### Documentation
- Add `License` section to `README.md`

### CI/CD
- Remove `.noderc.json` to allow unrestricted LTS updates
- Add `deploy.yml` support to `update-node-npm.yml` workflow
- Update `deploy.yml` node-version from `20.x` to `22.22.1`
- Fix `check-node.yml` matrix from `[20, 22]` to `[22.22.1]`
- Pin exact Node versions in `update-node-npm.yml` to prevent `EBADENGINE` errors

### Version
- Bump version from `3.5.1` to `3.6.0`

## 🧪 Tests
- [x] Verify `npm install` completes without errors:

```bash
npm install
```
- [x] Verify `npm run lint` passes:

```bash
npm run lint
```
- [x] Verify `npm run build` completes without errors:

```bash
npm run build
```
- [x] Verify `npm run serve` starts without errors:

```bash
npm run serve
```

## 🔗 References

### Related Issues
- Closes #910
- Closes #911
- Closes #912
- Closes #913
- Closes #922
- Closes #924
- Closes #925
- Closes #929
- Closes #977
- Closes #979